### PR TITLE
Fix an issue with files smaller than chunk size.

### DIFF
--- a/endpoint.php
+++ b/endpoint.php
@@ -53,6 +53,16 @@ if ($method == "POST") {
     // Assumes you have a chunking.success.endpoint set to point here with a query parameter of "done".
     // For example: /myserver/handlers/endpoint.php?done
     if (isset($_GET["done"])) {
+
+        // When the uploaded file is smaller than the chunk size, it is uploaded directy
+        // to the "files" folder, even is chunking.mandatory is set to true in the client.
+        $result["success"] = true;
+        $totalParts = isset($_REQUEST['qqtotalparts']) ? (int)$_REQUEST['qqtotalparts'] : 1;
+        if ($totalParts > 1) {
+            // Combine chunks
+            $result = $uploader->combineChunks($filesDir);
+        }
+
         $result = $uploader->combineChunks("files");
     }
     // Handles upload requests


### PR DESCRIPTION
If `chunking.mandatory` is set to `true` in the client but the file is smaller than the chunk size, the file is uploaded directly to the `files` folder bypassing the `chunks` folder. The call
```php
$result = $uploader->combineChunks("files");
```
then causes the correctly uploaded file to be overwritten by an empty file, since the necessary chunks do not exist.