### PR TITLE
Recursive mkdir() support

### DIFF
--- a/handler.php
+++ b/handler.php
@@ -58,7 +58,7 @@ class UploadHandler {
         $this->uploadName = $name;
 
         if (!file_exists($targetPath)){
-            mkdir(dirname($targetPath));
+            mkdir(dirname($targetPath), 0777, true);
         }
         $target = fopen($targetPath, 'wb');
 
@@ -179,7 +179,7 @@ class UploadHandler {
             $targetFolder = $this->chunksFolder.DIRECTORY_SEPARATOR.$uuid;
 
             if (!file_exists($targetFolder)){
-                mkdir($targetFolder);
+                mkdir($targetFolder, 0777, true);
             }
 
             $target = $targetFolder.'/'.$partIndex;
@@ -197,7 +197,7 @@ class UploadHandler {
                 $this->uploadName = basename($target);
 
                 if (!is_dir(dirname($target))){
-                    mkdir(dirname($target));
+                    mkdir(dirname($target), 0777, true);
                 }
                 if (move_uploaded_file($file['tmp_name'], $target)){
                     return array('success'=> true, "uuid" => $uuid);


### PR DESCRIPTION
If a user specifies a nested target directory (E.g., `uploads/subfolder`), `mkdir` will not create the intermediary folders. Add the recursive option to allow `mkdir` to create all of the necessary paths.