### PR TITLE
Handle delete requests made via `POST`

### DIFF
--- a/endpoint.php
+++ b/endpoint.php
@@ -46,7 +46,27 @@ $uploader->inputName = "qqfile"; // matches Fine Uploader's default inputName va
 // If you want to use the chunking/resume feature, specify the folder to temporarily save parts.
 $uploader->chunksFolder = "chunks";
 
-$method = $_SERVER["REQUEST_METHOD"];
+$method = get_request_method();
+
+// This will retrieve the "intended" request method.  Normally, this is the
+// actual method of the request.  Sometimes, though, the intended request method
+// must be hidden in the parameters of the request.  For example, when attempting to
+// delete a file using a POST request. In that case, "DELETE" will be sent along with
+// the request in a "_method" parameter.
+function get_request_method() {
+    global $HTTP_RAW_POST_DATA;
+
+    if(isset($HTTP_RAW_POST_DATA)) {
+    	parse_str($HTTP_RAW_POST_DATA, $_POST);
+    }
+
+    if (isset($_POST["_method"]) && $_POST["_method"] != null) {
+        return $_POST["_method"];
+    }
+
+    return $_SERVER["REQUEST_METHOD"];
+}
+
 if ($method == "POST") {
     header("Content-Type: text/plain");
 

--- a/handler.php
+++ b/handler.php
@@ -222,9 +222,19 @@ class UploadHandler {
         }
 
         $targetFolder = $uploadDirectory;
-        $url = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
-        $tokens = explode('/', $url);
-        $uuid = $tokens[sizeof($tokens)-1];
+        $uuid = false;
+        $method = $_SERVER["REQUEST_METHOD"];
+	    if ($method == "DELETE") {
+            $url = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+            $tokens = explode('/', $url);
+            $uuid = $tokens[sizeof($tokens)-1];
+        } else if ($method == "POST") {
+            $uuid = $_REQUEST['qquuid'];
+        } else {
+            return array("success" => false,
+                "error" => "Invalid request method! ".$method
+            );
+        }
 
         $target = join(DIRECTORY_SEPARATOR, array($targetFolder, $uuid));
 


### PR DESCRIPTION
If the user instructs FineUploader to use a `POST` request instead of a `DELETE` request, the handler will never clean up the file. E.g.,

```
deleteFile: {
        enabled: true,
        method: "POST"
    }
```

Automagically use the correct method to determine the file's `uuid` based on the server's `REQUEST_METHOD`.