### PR TITLE
Use the same request method in the handler and endpoint files

### DIFF
--- a/endpoint-cors.php
+++ b/endpoint-cors.php
@@ -45,32 +45,7 @@ $uploader->inputName = "qqfile"; // matches Fine Uploader's default inputName va
 // If you want to use the chunking/resume feature, specify the folder to temporarily save parts.
 $uploader->chunksFolder = "chunks";
 
-//$method = $_SERVER["REQUEST_METHOD"];
-$method = get_request_method();
-
-// This will retrieve the "intended" request method.  Normally, this is the
-// actual method of the request.  Sometimes, though, the intended request method
-// must be hidden in the parameters of the request.  For example, when attempting to
-// send a DELETE request in a cross-origin environment in IE9 or older, it is not
-// possible to send a DELETE request.  So, we send a POST with the intended method,
-// DELETE, in a "_method" parameter.
-function get_request_method() {
-    global $HTTP_RAW_POST_DATA;
-
-    // This should only evaluate to true if the Content-Type is undefined
-    // or unrecognized, such as when XDomainRequest has been used to
-    // send the request.
-    if(isset($HTTP_RAW_POST_DATA)) {
-    	parse_str($HTTP_RAW_POST_DATA, $_POST);
-    }
-
-    if (isset($_POST["_method"]) && $_POST["_method"] != null) {
-        return $_POST["_method"];
-    }
-
-    return $_SERVER["REQUEST_METHOD"];
-}
-
+$method = UploadHandler::get_request_method();
 
 function parseRequestHeaders() {
     $headers = array();

--- a/endpoint.php
+++ b/endpoint.php
@@ -46,27 +46,7 @@ $uploader->inputName = "qqfile"; // matches Fine Uploader's default inputName va
 // If you want to use the chunking/resume feature, specify the folder to temporarily save parts.
 $uploader->chunksFolder = "chunks";
 
-$method = get_request_method();
-
-// This will retrieve the "intended" request method.  Normally, this is the
-// actual method of the request.  Sometimes, though, the intended request method
-// must be hidden in the parameters of the request.  For example, when attempting to
-// delete a file using a POST request. In that case, "DELETE" will be sent along with
-// the request in a "_method" parameter.
-function get_request_method() {
-    global $HTTP_RAW_POST_DATA;
-
-    if(isset($HTTP_RAW_POST_DATA)) {
-    	parse_str($HTTP_RAW_POST_DATA, $_POST);
-    }
-
-    if (isset($_POST["_method"]) && $_POST["_method"] != null) {
-        return $_POST["_method"];
-    }
-
-    return $_SERVER["REQUEST_METHOD"];
-}
-
+$method = UploadHandler::get_request_method();
 if ($method == "POST") {
     header("Content-Type: text/plain");
 

--- a/handler.php
+++ b/handler.php
@@ -19,6 +19,28 @@ class UploadHandler {
     protected $uploadName;
 
     /**
+     * This will retrieve the "intended" request method.  Normally, this is the
+     * actual method of the request.  Sometimes, though, the intended request method
+     * must be hidden in the parameters of the request.  For example, when attempting to
+     * delete a file using a POST request. In that case, "DELETE" will be sent along with
+     * the request in a "_method" parameter.
+     * @return string HTTP method used for the request. E.g., DELETE, POST, etc.
+     */
+    public static function get_request_method() {
+        global $HTTP_RAW_POST_DATA;
+
+        if(isset($HTTP_RAW_POST_DATA)) {
+            parse_str($HTTP_RAW_POST_DATA, $_POST);
+        }
+
+        if (isset($_POST["_method"]) && $_POST["_method"] != null) {
+            return $_POST["_method"];
+        }
+
+        return $_SERVER["REQUEST_METHOD"];
+    }
+
+    /**
      * Get the original filename
      */
     public function getName(){
@@ -138,7 +160,7 @@ class UploadHandler {
         if($file['error']) {
             return array('error' => 'Upload Error #'.$file['error']);
         }
-        	
+
         // Validate name
         if ($name === null || $name === ''){
             return array('error' => 'File name empty.');
@@ -223,7 +245,7 @@ class UploadHandler {
 
         $targetFolder = $uploadDirectory;
         $uuid = false;
-        $method = $_SERVER["REQUEST_METHOD"];
+        $method = self::get_request_method();
 	    if ($method == "DELETE") {
             $url = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
             $tokens = explode('/', $url);


### PR DESCRIPTION
Use the same request methodology in both the `UploadHandler` class and
endpoint files. The method is now a static function on the
`UploadHandler` class to allow both functions a clean way for code
re-use.