### PR TITLE
Let one-part chunks be handled as chunks and not standard uploads

### DIFF
--- a/handler.php
+++ b/handler.php
@@ -138,7 +138,7 @@ class UploadHandler {
         if($file['error']) {
             return array('error' => 'Upload Error #'.$file['error']);
         }
-        	
+
         // Validate name
         if ($name === null || $name === ''){
             return array('error' => 'File name empty.');
@@ -163,10 +163,10 @@ class UploadHandler {
         }
 
         // Save a chunk
-        $totalParts = isset($_REQUEST['qqtotalparts']) ? (int)$_REQUEST['qqtotalparts'] : 1;
+        $totalParts = isset($_REQUEST['qqtotalparts']) ? (int)$_REQUEST['qqtotalparts'] : 0;
 
         $uuid = $_REQUEST['qquuid'];
-        if ($totalParts > 1){
+        if ($totalParts > 0){
         # chunked upload
 
             $chunksFolder = $this->chunksFolder;


### PR DESCRIPTION
I'm not sure why the $totalParts was set to 1 when it's not set, typically, for a non-chunked upload.

This was the reason why, when setting `chunking.mandatory` to `true`, the upload wasn't properly handled when the file was small enough to fit in a single chunk.

It's a duplicate of #6 and #9, but this should be the proper behaviour according to me. If we ask for chunking to be mandatory, the server handler should also treat the request as a chunked upload.
