### PR TITLE
sends proper application/json content type header

### DIFF
--- a/endpoint.php
+++ b/endpoint.php
@@ -68,7 +68,7 @@ function get_request_method() {
 }
 
 if ($method == "POST") {
-    header("Content-Type: text/plain");
+    header("Content-Type: application/json");
 
     // Assumes you have a chunking.success.endpoint set to point here with a query parameter of "done".
     // For example: /myserver/handlers/endpoint.php?done


### PR DESCRIPTION
On lines 87 and 92 we are explicitly sending json, may as well send the proper content type to appease browsers.