### PR TITLE
Bug fix in combineChunks

### DIFF
--- a/handler.php
+++ b/handler.php
@@ -57,7 +57,7 @@ class UploadHandler {
         $targetPath = join(DIRECTORY_SEPARATOR, array($uploadDirectory, $uuid, $name));
         $this->uploadName = $name;
 
-        if (!file_exists($targetPath)){
+        if (!file_exists(dirname($targetPath))){
             mkdir(dirname($targetPath), 0777, true);
         }
         $target = fopen($targetPath, 'wb');


### PR DESCRIPTION
You have to mkdir the chunk directory only if dirname($targetPath) not exists, not $targetPath with is a file.